### PR TITLE
Delete OS description in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ network: unix
 address: ~/.opener.sock
 ```
 
-### Example: Open a URL from inside a container on macOS
+### Example: Open a URL from inside a container
 
-If you want to open a URL from inside a container on macOS, you can use `tcp` network instead of `unix`.
+If you want to open a URL from inside a container, you can use `tcp` network instead of `unix`.
 
 ```
 ┌─────────────────────────────────────────────────────────┐


### PR DESCRIPTION
Since opener now works fine on GNU Linux as well as on macOS, this PR deletes OS description in README.md.