### PR TITLE
Improve remote opener binary

### DIFF
--- a/bin/open
+++ b/bin/open
@@ -1,7 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-if [ -p /dev/stdin ]; then
-    cat - | nc -U "$HOME/.opener.sock"
+set -eu
+
+# get data either form stdin or from file
+if (( $# == 0 )) ; then
+  # if no argument, read from standard input from pipe
+  buf=$(cat "$@")
 else
-    echo "${@}" | nc -U "$HOME/.opener.sock"
+  # otherwise read from all arguments
+  buf=$@
 fi
+
+echo "$buf" | nc -U "$HOME/.opener.sock"

--- a/bin/xdg-open
+++ b/bin/xdg-open
@@ -1,7 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-if [ -p /dev/stdin ]; then
-    cat - | nc -U "$HOME/.opener.sock"
+set -eu
+
+# get data either form stdin or from file
+if (( $# == 0 )) ; then
+  # if no argument, read from standard input from pipe
+  buf=$(cat "$@")
 else
-    echo "${@}" | nc -U "$HOME/.opener.sock"
+  # otherwise read from all arguments
+  buf=$@
 fi
+
+echo "$buf" | nc -U "$HOME/.opener.sock"


### PR DESCRIPTION
This PR improves remote opener binaries. It checks the number of arguments instead of checking `/dev/stdin`

In the following case
```
echo "https://www.facebook.com\nhttps://www.google.com" | \
    while read -r chosen; do
        ./bin/open $chosen
    done
```

It has `/dev/stdin` but we actually need to read from arguments instead of `stdin`.


 Also verified that the following still works
```
echo "https://www.google.com" | ./bin/open
```
```
./bin/open "https://www.google.com"
```