### PR TITLE
feat: auto-forward SSH ports for localhost URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ network: unix
 address: ~/.opener.sock
 
 # SSH control socket for automatic port forwarding (optional, see below).
-control-socket: ~/.ssh/cm_socket/my-remote
+auto-forward-control-socket: ~/.ssh/cm_socket/my-remote
 
 # How long to keep a forwarded port before cleaning it up. (defaults to 1m)
-forward-ttl: 60s
+auto-forward-ttl: 60s
 ```
 
 ### Automatic SSH port forwarding
@@ -115,12 +115,12 @@ This is common with OAuth callback flows where a CLI tool like `az login` or
 `http://localhost:38947/callback`). When you are working on a remote server
 over SSH, these URLs fail because the port is not forwarded.
 
-If you set `control-socket` in your config, opener will detect localhost URLs
+If you set `auto-forward-control-socket` in your config, opener will detect localhost URLs
 with non-standard ports and automatically set up SSH port forwards using your
 existing SSH connection. This works for both direct localhost URLs and localhost
 URLs embedded in query parameters (like `redirect_uri`).
 
-Forwards are cleaned up automatically after `forward-ttl` (default 1 minute).
+Forwards are cleaned up automatically after `auto-forward-ttl` (default 1 minute).
 
 To use this feature:
 
@@ -136,14 +136,14 @@ Host my-remote
 2. Add the same path to your opener config (`~/.config/opener/config.yaml`):
 
 ```yaml
-control-socket: ~/.ssh/cm_socket/my-remote
-forward-ttl: 60s
+auto-forward-control-socket: ~/.ssh/cm_socket/my-remote
+auto-forward-ttl: 60s
 ```
 
 When opener receives a URL like
 `https://login.example.com/?redirect_uri=http%3A%2F%2Flocalhost%3A54123%2Fcallback`,
 it will run `ssh -S ~/.ssh/cm_socket/my-remote -O forward -L 54123:localhost:54123 none`
-before opening the URL in your browser. After `forward-ttl` elapses the port
+before opening the URL in your browser. After `auto-forward-ttl` elapses the port
 forward is removed with `ssh -O cancel`.
 
 ### Example: Open a URL from inside a container

--- a/README.md
+++ b/README.md
@@ -99,7 +99,52 @@ network: unix
 
 # The address to listen on. (defaults to ~/.opener.sock)
 address: ~/.opener.sock
+
+# SSH control socket for automatic port forwarding (optional, see below).
+control-socket: ~/.ssh/cm_socket/my-remote
+
+# How long to keep a forwarded port before cleaning it up. (defaults to 1m)
+forward-ttl: 60s
 ```
+
+### Automatic SSH port forwarding
+
+Some URLs opened through opener point to `localhost` on a non-standard port.
+This is common with OAuth callback flows where a CLI tool like `az login` or
+`gcloud auth login` starts a temporary local HTTP server (for example
+`http://localhost:38947/callback`). When you are working on a remote server
+over SSH, these URLs fail because the port is not forwarded.
+
+If you set `control-socket` in your config, opener will detect localhost URLs
+with non-standard ports and automatically set up SSH port forwards using your
+existing SSH connection. This works for both direct localhost URLs and localhost
+URLs embedded in query parameters (like `redirect_uri`).
+
+Forwards are cleaned up automatically after `forward-ttl` (default 1 minute).
+
+To use this feature:
+
+1. Enable SSH connection sharing with a static control socket path in your `~/.ssh/config`:
+
+```
+Host my-remote
+  ControlMaster auto
+  ControlPath ~/.ssh/cm_socket/my-remote
+  ControlPersist 60m
+```
+
+2. Add the same path to your opener config (`~/.config/opener/config.yaml`):
+
+```yaml
+control-socket: ~/.ssh/cm_socket/my-remote
+forward-ttl: 60s
+```
+
+When opener receives a URL like
+`https://login.example.com/?redirect_uri=http%3A%2F%2Flocalhost%3A54123%2Fcallback`,
+it will run `ssh -S ~/.ssh/cm_socket/my-remote -O forward -L 54123:localhost:54123 none`
+before opening the URL in your browser. After `forward-ttl` elapses the port
+forward is removed with `ssh -O cancel`.
 
 ### Example: Open a URL from inside a container
 

--- a/config_test.go
+++ b/config_test.go
@@ -32,6 +32,17 @@ func TestLoadOptionsFromConfig(t *testing.T) {
 			"",
 		},
 		{
+			"ssh-forward",
+			filepath.Join("testdata", "config", "ssh-forward.yaml"),
+			&OpenerOptions{
+				Network:       "unix",
+				Address:       "~/.opener.sock",
+				ControlSocket: "~/.ssh/ctrl-socket",
+				ForwardTTLRaw: "5m",
+			},
+			"",
+		},
+		{
 			"empty",
 			filepath.Join("testdata", "config", "empty.yaml"),
 			&OpenerOptions{},

--- a/forward.go
+++ b/forward.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -72,65 +73,85 @@ func loopbackPort(u *url.URL) string {
 }
 
 type forwardTracker struct {
-	mu            sync.Mutex
-	active        map[string]time.Time // port -> last forwarded time
-	controlSocket string
-	ttl           time.Duration
-	errOut        io.Writer
+	mu         sync.Mutex
+	active     map[string]time.Time // port -> last forwarded time
+	ttl        time.Duration
+	errOut     io.Writer
+	sshControlCmdFunc func(ctx context.Context, operation, port string) *exec.Cmd
 }
 
 func newForwardTracker(controlSocket string, ttl time.Duration, errOut io.Writer) *forwardTracker {
 	return &forwardTracker{
-		active:        make(map[string]time.Time),
-		controlSocket: controlSocket,
-		ttl:           ttl,
-		errOut:        errOut,
+		active: make(map[string]time.Time),
+		ttl:    ttl,
+		errOut: errOut,
+		sshControlCmdFunc: func(ctx context.Context, op, port string) *exec.Cmd {
+			return exec.CommandContext(ctx, "ssh", "-S", controlSocket, "-O", op, "-L", port+":localhost:"+port, "none")
+		},
 	}
 }
 
 func (ft *forwardTracker) forward(port string) {
-	ctx, cancel := context.WithTimeout(context.Background(), sshForwardTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "ssh", "-S", ft.controlSocket, "-O", "forward", "-L", port+":localhost:"+port, "none")
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	err := cmd.Run()
 	ft.mu.Lock()
-	if err != nil {
-		if ft.errOut != nil {
-			fmt.Fprintf(ft.errOut, "opener: ssh forward -L %s:localhost:%s: %v\n", port, port, err)
-		}
+	if _, exists := ft.active[port]; exists {
+		ft.active[port] = time.Now()
 		ft.mu.Unlock()
+		if ft.errOut != nil {
+			fmt.Fprintf(ft.errOut, "opener: port %s already forwarded, refreshing TTL\n", port)
+		}
 		return
 	}
+	// Mark the port as in-progress to prevent duplicate ssh execs.
 	ft.active[port] = time.Now()
 	ft.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), sshForwardTimeout)
+	defer cancel()
+	cmd := ft.sshControlCmdFunc(ctx, "forward", port)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	if err != nil {
+		ft.mu.Lock()
+		delete(ft.active, port)
+		ft.mu.Unlock()
+		if ft.errOut != nil {
+			fmt.Fprintf(ft.errOut, "opener: ssh forward -L %s:localhost:%s: %v: %s\n", port, port, err, stderr.String())
+		}
+		return
+	}
+
 	if ft.errOut != nil {
 		fmt.Fprintf(ft.errOut, "opener: forwarded -L %s:localhost:%s\n", port, port)
 	}
 }
 
+func (ft *forwardTracker) cancelForward(port string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), sshForwardTimeout)
+	defer cancel()
+	cmd := ft.sshControlCmdFunc(ctx, "cancel", port)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}
+
 func (ft *forwardTracker) cleanup() {
 	ft.mu.Lock()
-	expired := make([]string, 0)
+	defer ft.mu.Unlock()
+
 	now := time.Now()
 	for port, ts := range ft.active {
-		if now.Sub(ts) > ft.ttl {
-			expired = append(expired, port)
+		if now.Sub(ts) <= ft.ttl {
+			continue
 		}
-	}
-	for _, port := range expired {
-		delete(ft.active, port)
-	}
-	ft.mu.Unlock()
-
-	for _, port := range expired {
-		ctx, cancel := context.WithTimeout(context.Background(), sshForwardTimeout)
-		cmd := exec.CommandContext(ctx, "ssh", "-S", ft.controlSocket, "-O", "cancel", "-L", port+":localhost:"+port, "none")
-		cmd.Stdout = nil
-		cmd.Stderr = nil
-		err := cmd.Run()
-		cancel()
+		err := ft.cancelForward(port)
+		if err == nil {
+			delete(ft.active, port)
+		}
 		if ft.errOut != nil {
 			if err != nil {
 				fmt.Fprintf(ft.errOut, "opener: ssh cancel -L %s:localhost:%s: %v\n", port, port, err)
@@ -144,6 +165,7 @@ func (ft *forwardTracker) cleanup() {
 func (ft *forwardTracker) run(ctx context.Context) {
 	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():

--- a/forward.go
+++ b/forward.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const sshForwardTimeout = 3 * time.Second
+const cleanupInterval = 10 * time.Second
+
+// shouldForward parses rawURL and returns a non-standard loopback port if the URL
+// (or any query parameter value parsed as a URL) refers to localhost with a
+// non-standard port. Query parameters are scanned in the order they appear in
+// the raw URL. Returns "", false if no such port is found or on parse errors.
+func shouldForward(rawURL string) (port string, ok bool) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", false
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	if p := loopbackPort(u); p != "" {
+		return p, true
+	}
+	// Iterate over the raw query string to preserve parameter order.
+	for _, param := range strings.Split(u.RawQuery, "&") {
+		_, v, _ := strings.Cut(param, "=")
+		v, err := url.QueryUnescape(v)
+		if err != nil {
+			continue
+		}
+		sub, err := url.Parse(v)
+		if err != nil {
+			continue
+		}
+		if p := loopbackPort(sub); p != "" {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// loopbackPort returns the port from u if u's host is loopback and the port is
+// present and not 80 or 443. Otherwise returns "".
+func loopbackPort(u *url.URL) string {
+	host := u.Hostname()
+	if host == "" {
+		return ""
+	}
+	host = strings.ToLower(host)
+	if host != "localhost" && host != "127.0.0.1" && host != "::1" {
+		return ""
+	}
+	port := u.Port()
+	if port == "" || port == "80" || port == "443" {
+		return ""
+	}
+	n, err := strconv.Atoi(port)
+	if err != nil || n < 1 || n > 65535 {
+		return ""
+	}
+	return port
+}
+
+type forwardTracker struct {
+	mu            sync.Mutex
+	active        map[string]time.Time // port -> last forwarded time
+	controlSocket string
+	ttl           time.Duration
+	errOut        io.Writer
+}
+
+func newForwardTracker(controlSocket string, ttl time.Duration, errOut io.Writer) *forwardTracker {
+	return &forwardTracker{
+		active:        make(map[string]time.Time),
+		controlSocket: controlSocket,
+		ttl:           ttl,
+		errOut:        errOut,
+	}
+}
+
+func (ft *forwardTracker) forward(port string) {
+	ctx, cancel := context.WithTimeout(context.Background(), sshForwardTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ssh", "-S", ft.controlSocket, "-O", "forward", "-L", port+":localhost:"+port, "none")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	err := cmd.Run()
+	ft.mu.Lock()
+	if err != nil {
+		if ft.errOut != nil {
+			fmt.Fprintf(ft.errOut, "opener: ssh forward -L %s:localhost:%s: %v\n", port, port, err)
+		}
+		ft.mu.Unlock()
+		return
+	}
+	ft.active[port] = time.Now()
+	ft.mu.Unlock()
+	if ft.errOut != nil {
+		fmt.Fprintf(ft.errOut, "opener: forwarded -L %s:localhost:%s\n", port, port)
+	}
+}
+
+func (ft *forwardTracker) cleanup() {
+	ft.mu.Lock()
+	expired := make([]string, 0)
+	now := time.Now()
+	for port, ts := range ft.active {
+		if now.Sub(ts) > ft.ttl {
+			expired = append(expired, port)
+		}
+	}
+	for _, port := range expired {
+		delete(ft.active, port)
+	}
+	ft.mu.Unlock()
+
+	for _, port := range expired {
+		ctx, cancel := context.WithTimeout(context.Background(), sshForwardTimeout)
+		cmd := exec.CommandContext(ctx, "ssh", "-S", ft.controlSocket, "-O", "cancel", "-L", port+":localhost:"+port, "none")
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		err := cmd.Run()
+		cancel()
+		if ft.errOut != nil {
+			if err != nil {
+				fmt.Fprintf(ft.errOut, "opener: ssh cancel -L %s:localhost:%s: %v\n", port, port, err)
+			} else {
+				fmt.Fprintf(ft.errOut, "opener: cancelled forward -L %s:localhost:%s\n", port, port)
+			}
+		}
+	}
+}
+
+func (ft *forwardTracker) run(ctx context.Context) {
+	ticker := time.NewTicker(cleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ft.cleanup()
+		}
+	}
+}

--- a/forward_test.go
+++ b/forward_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os/exec"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -150,25 +153,40 @@ func TestShouldForward(t *testing.T) {
 }
 
 func TestForwardTrackerCleanup(t *testing.T) {
-	// Test that cleanup() removes expired entries and keeps non-expired.
-	// We don't exec ssh; we only check that the active map is updated.
-	// forward() would need to run ssh; we test cleanup in isolation by
-	// populating active directly and calling cleanup with a short TTL.
-	ft := newForwardTracker("/nonexistent/socket", 100*time.Millisecond, io.Discard)
-	ft.mu.Lock()
-	ft.active["11111"] = time.Now().Add(-200 * time.Millisecond) // expired
-	ft.active["22222"] = time.Now().Add(-50 * time.Millisecond)  // not expired
-	ft.mu.Unlock()
-
-	ft.cleanup()
-
-	ft.mu.Lock()
-	defer ft.mu.Unlock()
-	if _, ok := ft.active["11111"]; ok {
-		t.Error("expired entry 11111 should have been removed")
+	tt := []struct {
+		name            string
+		cancelCmd       string // "true" (exit 0) or "false" (exit 1)
+		expiredRemoved  bool
+	}{
+		{"cancel succeeds", "true", true},
+		{"cancel fails", "false", false},
 	}
-	if _, ok := ft.active["22222"]; !ok {
-		t.Error("non-expired entry 22222 should remain")
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ft := newForwardTracker("/unused", 100*time.Millisecond, io.Discard)
+			ft.sshControlCmdFunc = func(ctx context.Context, op, port string) *exec.Cmd {
+				return exec.Command(tc.cancelCmd)
+			}
+			ft.mu.Lock()
+			ft.active["11111"] = time.Now().Add(-200 * time.Millisecond) // expired
+			ft.active["22222"] = time.Now().Add(-50 * time.Millisecond)  // not expired
+			ft.mu.Unlock()
+
+			ft.cleanup()
+
+			ft.mu.Lock()
+			defer ft.mu.Unlock()
+			_, expiredExists := ft.active["11111"]
+			if tc.expiredRemoved && expiredExists {
+				t.Error("expired entry 11111 should be removed after successful cancel")
+			}
+			if !tc.expiredRemoved && !expiredExists {
+				t.Error("expired entry 11111 should remain when ssh cancel fails")
+			}
+			if _, ok := ft.active["22222"]; !ok {
+				t.Error("non-expired entry 22222 should remain")
+			}
+		})
 	}
 }
 
@@ -193,7 +211,28 @@ func TestForwardTrackerForwardLogsError(t *testing.T) {
 	var buf bytes.Buffer
 	ft := newForwardTracker("/nonexistent/control/socket", time.Minute, &buf)
 	ft.forward("12345")
-	if buf.Len() == 0 {
-		t.Error("expected error to be logged when ssh fails")
+	if !strings.Contains(buf.String(), "opener: ssh forward -L") {
+		t.Errorf("expected forward error log, got: %s", buf.String())
+	}
+}
+
+func TestForwardTrackerForwardDedup(t *testing.T) {
+	var calls atomic.Int32
+	ft := newForwardTracker("/unused", time.Minute, io.Discard)
+	ft.sshControlCmdFunc = func(ctx context.Context, op, port string) *exec.Cmd {
+		calls.Add(1)
+		return exec.Command("true")
+	}
+
+	ft.forward("12345")
+	ft.forward("12345")
+
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected ssh to be called once, got %d", n)
+	}
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	if _, ok := ft.active["12345"]; !ok {
+		t.Error("port should remain in active map")
 	}
 }

--- a/forward_test.go
+++ b/forward_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestShouldForward(t *testing.T) {
+	tt := []struct {
+		name     string
+		rawURL   string
+		wantPort string
+		wantOK   bool
+	}{
+		// Direct localhost URLs
+		{
+			name:     "direct localhost with port",
+			rawURL:   "http://localhost:12345/callback",
+			wantPort: "12345",
+			wantOK:   true,
+		},
+		{
+			name:     "direct 127.0.0.1 with port",
+			rawURL:   "http://127.0.0.1:54321/auth",
+			wantPort: "54321",
+			wantOK:   true,
+		},
+		{
+			name:     "direct IPv6 loopback with port",
+			rawURL:   "http://[::1]:9999/cb",
+			wantPort: "9999",
+			wantOK:   true,
+		},
+		// Query param extraction
+		{
+			name:     "redirect_uri in query",
+			rawURL:   "https://login.microsoftonline.com/tenant/oauth2?redirect_uri=http%3A%2F%2Flocalhost%3A38947&client_id=foo",
+			wantPort: "38947",
+			wantOK:   true,
+		},
+		{
+			name:     "callback in query 127.0.0.1",
+			rawURL:   "https://accounts.google.com/o/oauth2?callback=http%3A%2F%2F127.0.0.1%3A12345%2Fcb",
+			wantPort: "12345",
+			wantOK:   true,
+		},
+		{
+			name:     "azure cli oauth",
+			rawURL:   "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?client_id=xxx&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A38947&scope=https%3A%2F%2Fmanagement.core.windows.net%2F%2F.default+offline_access+openid+profile&state=xxx&code_challenge=xxx&code_challenge_method=S256&nonce=xxx&client_info=1&claims=%7B%22access_token%22%3A+%7B%22xms_cc%22%3A+%7B%22values%22%3A+%5B%22CP1%22%5D%7D%7D%7D&prompt=select_account",
+			wantPort: "38947",
+			wantOK:   true,
+		},
+		{
+			name:     "gcloud cli oauth",
+			rawURL:   "https://accounts.google.com/o/oauth2/auth?response_type=code&client_id=32555940559.apps.googleusercontent.com&redirect_uri=http%3A%2F%2Flocalhost%3A8085%2F&scope=openid+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.email+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fappengine.admin+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fsqlservice.login+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcompute+https%3A%2F%2Fwww.googleapis.com%2Fauth%2Faccounts.reauth&state=xxx&access_type=offline&code_challenge=xxx&code_challenge_method=S256",
+			wantPort: "8085",
+			wantOK:   true,
+		},
+		{
+			name:     "first of multiple localhost params wins",
+			rawURL:   "https://example.com/?foo=http%3A%2F%2Flocalhost%3A9999&bar=http%3A%2F%2Flocalhost%3A8888",
+			wantPort: "9999",
+			wantOK:   true,
+		},
+		// Should not forward
+		{
+			name:     "non-localhost URL no localhost in params",
+			rawURL:   "https://accounts.google.com/o/oauth2",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "redirect_uri is not localhost",
+			rawURL:   "https://example.com/?redirect_uri=https%3A%2F%2Fexample.com%2Fcallback",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "localhost without port implies 80",
+			rawURL:   "https://example.com/?redirect_uri=http%3A%2F%2Flocalhost%2Fpath",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "direct localhost path no port",
+			rawURL:   "http://localhost/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "standard port 443 skip",
+			rawURL:   "http://localhost:443/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "standard port 80 skip",
+			rawURL:   "http://localhost:80/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "non-numeric port rejected",
+			rawURL:   "http://localhost:abc/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "port 0 rejected",
+			rawURL:   "http://localhost:0/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "port exceeding 65535 rejected",
+			rawURL:   "http://localhost:99999/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "negative port rejected",
+			rawURL:   "http://localhost:-1/path",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "malformed URL",
+			rawURL:   "not-a-url",
+			wantPort: "",
+			wantOK:   false,
+		},
+		{
+			name:     "empty string",
+			rawURL:   "",
+			wantPort: "",
+			wantOK:   false,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			port, ok := shouldForward(tc.rawURL)
+			if ok != tc.wantOK || port != tc.wantPort {
+				t.Errorf("shouldForward(%q) = %q, %v; want %q, %v", tc.rawURL, port, ok, tc.wantPort, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestForwardTrackerCleanup(t *testing.T) {
+	// Test that cleanup() removes expired entries and keeps non-expired.
+	// We don't exec ssh; we only check that the active map is updated.
+	// forward() would need to run ssh; we test cleanup in isolation by
+	// populating active directly and calling cleanup with a short TTL.
+	ft := newForwardTracker("/nonexistent/socket", 100*time.Millisecond, io.Discard)
+	ft.mu.Lock()
+	ft.active["11111"] = time.Now().Add(-200 * time.Millisecond) // expired
+	ft.active["22222"] = time.Now().Add(-50 * time.Millisecond)  // not expired
+	ft.mu.Unlock()
+
+	ft.cleanup()
+
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	if _, ok := ft.active["11111"]; ok {
+		t.Error("expired entry 11111 should have been removed")
+	}
+	if _, ok := ft.active["22222"]; !ok {
+		t.Error("non-expired entry 22222 should remain")
+	}
+}
+
+func TestForwardTrackerRunExitsOnContextCancel(t *testing.T) {
+	ft := newForwardTracker("/nonexistent/socket", time.Minute, io.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		ft.run(ctx)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+		// run() exited
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not exit after context cancel")
+	}
+}
+
+func TestForwardTrackerForwardLogsError(t *testing.T) {
+	var buf bytes.Buffer
+	ft := newForwardTracker("/nonexistent/control/socket", time.Minute, &buf)
+	ft.forward("12345")
+	if buf.Len() == 0 {
+		t.Error("expected error to be logged when ssh fails")
+	}
+}

--- a/opener.go
+++ b/opener.go
@@ -29,8 +29,8 @@ var (
 type OpenerOptions struct {
 	Network       string `json:"network"`
 	Address       string `json:"address"`
-	ControlSocket string `json:"control-socket"`
-	ForwardTTLRaw string `json:"forward-ttl"`
+	ControlSocket string `json:"auto-forward-control-socket"`
+	ForwardTTLRaw string `json:"auto-forward-ttl"`
 
 	ForwardTTL time.Duration
 	ErrOut     io.Writer
@@ -94,7 +94,7 @@ func (o *OpenerOptions) Validate() error {
 		if o.ForwardTTLRaw != "" {
 			d, err := time.ParseDuration(o.ForwardTTLRaw)
 			if err != nil {
-				return fmt.Errorf("invalid forward-ttl %q: %w", o.ForwardTTLRaw, err)
+				return fmt.Errorf("invalid auto-forward-ttl %q: %w", o.ForwardTTLRaw, err)
 			}
 			o.ForwardTTL = d
 		}
@@ -119,7 +119,7 @@ func (o *OpenerOptions) Run() error {
 
 	var ft *forwardTracker
 	if o.ControlSocket != "" {
-		fmt.Fprintf(o.ErrOut, "Starting auto socket forwarder. ControlSocket: %q, forward-ttl: %q\n", o.ControlSocket, o.ForwardTTL)
+		fmt.Fprintf(o.ErrOut, "Starting auto socket forwarder. auto-forward-control-socket: %q, auto-forward-ttl: %q\n", o.ControlSocket, o.ForwardTTL)
 		ctx, cancel := context.WithCancel(context.Background())
 		ft = newForwardTracker(o.ControlSocket, o.ForwardTTL, o.ErrOut)
 		go ft.run(ctx)
@@ -189,7 +189,6 @@ func handleConnection(conn net.Conn, errOut io.Writer, tracker *forwardTracker) 
 
 	if tracker != nil {
 		if port, ok := shouldForward(line); ok {
-			fmt.Fprintf(errOut, "opener: detected localhost port %q, requesting forward\n", port)
 			tracker.forward(port)
 		}
 	}

--- a/opener.go
+++ b/opener.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,21 +13,27 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
-var version string
-var commit string
-var date string
+var (
+	version string
+	commit  string
+	date    string
+)
 
 type OpenerOptions struct {
-	Network string `yaml:"network"`
-	Address string `yaml:"address"`
+	Network       string `json:"network"`
+	Address       string `json:"address"`
+	ControlSocket string `json:"control-socket"`
+	ForwardTTLRaw string `json:"forward-ttl"`
 
-	ErrOut io.Writer
+	ForwardTTL time.Duration
+	ErrOut     io.Writer
 }
 
 func NewOpenerCmd(errOut io.Writer) *cobra.Command {
@@ -77,6 +84,25 @@ func (o *OpenerOptions) Validate() error {
 		return errors.New("allowed network are: unix,tcp")
 	}
 
+	if o.ControlSocket != "" {
+		expanded, err := homedir.Expand(o.ControlSocket)
+		if err != nil {
+			return err
+		}
+		o.ControlSocket = expanded
+
+		if o.ForwardTTLRaw != "" {
+			d, err := time.ParseDuration(o.ForwardTTLRaw)
+			if err != nil {
+				return fmt.Errorf("invalid forward-ttl %q: %w", o.ForwardTTLRaw, err)
+			}
+			o.ForwardTTL = d
+		}
+		if o.ForwardTTL == 0 {
+			o.ForwardTTL = time.Minute
+		}
+	}
+
 	return nil
 }
 
@@ -91,6 +117,15 @@ func (o *OpenerOptions) Run() error {
 
 	defer ln.Close()
 
+	var ft *forwardTracker
+	if o.ControlSocket != "" {
+		fmt.Fprintf(o.ErrOut, "Starting auto socket forwarder. ControlSocket: %q, forward-ttl: %q\n", o.ControlSocket, o.ForwardTTL)
+		ctx, cancel := context.WithCancel(context.Background())
+		ft = newForwardTracker(o.ControlSocket, o.ForwardTTL, o.ErrOut)
+		go ft.run(ctx)
+		defer cancel()
+	}
+
 	go func() {
 		for {
 			conn, err := ln.Accept()
@@ -99,7 +134,7 @@ func (o *OpenerOptions) Run() error {
 				return
 			}
 
-			go handleConnection(conn, o.ErrOut)
+			go handleConnection(conn, o.ErrOut, ft)
 		}
 	}()
 
@@ -139,7 +174,7 @@ var openURL = func(line string) (string, error) {
 	return buf.String(), err
 }
 
-func handleConnection(conn net.Conn, errOut io.Writer) {
+func handleConnection(conn net.Conn, errOut io.Writer, tracker *forwardTracker) {
 	defer conn.Close()
 
 	line, err := bufio.NewReader(conn).ReadString('\n')
@@ -149,6 +184,13 @@ func handleConnection(conn net.Conn, errOut io.Writer) {
 		if err != io.EOF {
 			fmt.Fprintln(errOut, err)
 			return
+		}
+	}
+
+	if tracker != nil {
+		if port, ok := shouldForward(line); ok {
+			fmt.Fprintf(errOut, "opener: detected localhost port %q, requesting forward\n", port)
+			tracker.forward(port)
 		}
 	}
 

--- a/opener_test.go
+++ b/opener_test.go
@@ -92,7 +92,7 @@ func TestHandleConnection(t *testing.T) {
 
 			go func() {
 				conn, _ := ln.Accept()
-				go handleConnection(conn, io.Discard)
+				go handleConnection(conn, io.Discard, nil)
 			}()
 
 			client, err := net.Dial("tcp", ln.Addr().String())

--- a/testdata/config/ssh-forward.yaml
+++ b/testdata/config/ssh-forward.yaml
@@ -1,4 +1,4 @@
 network: unix
 address: ~/.opener.sock
-control-socket: ~/.ssh/ctrl-socket
-forward-ttl: 5m
+auto-forward-control-socket: ~/.ssh/ctrl-socket
+auto-forward-ttl: 5m

--- a/testdata/config/ssh-forward.yaml
+++ b/testdata/config/ssh-forward.yaml
@@ -1,0 +1,4 @@
+network: unix
+address: ~/.opener.sock
+control-socket: ~/.ssh/ctrl-socket
+forward-ttl: 5m


### PR DESCRIPTION
When opener detects a URL targeting localhost with a non-standard port (either directly or embedded in a query parameter like redirect_uri), automatically set up an SSH port forward via an existing control socket. Forwards are tracked and cleaned up after a configurable TTL (default 1m).

This is useful when running opener on a remote host over SSH with localhost OAuth callbacks and similar flows now work without manual -L forwarding.

Example config:

```
# ~/ssh/config
Host my-remote
    ControlMaster  auto
    ControlPath    ~/.ssh/cm_socket/my-remote
    ControlPersist 60m
```

```
#  ~/.config/opener/config.yaml
control-socket: ~/.ssh/cm_socket/my-remote
forward-ttl: 60s
```

Then, when running a command on the remote vm such as `az login` or `gcloud auth` which open a port on localhost for the callback, opener will automatically run `ssh -S ~/.ssh/cm_socket/my-remote -O forward -L 54123:localhost:54123`. After `forward-ttl` elapses the port forward is removed with the `ssh -O cancel` command.